### PR TITLE
Adjust checkout details table markup for accessibility

### DIFF
--- a/src/components/checkout-details.js
+++ b/src/components/checkout-details.js
@@ -34,6 +34,9 @@ function CheckoutDetails() {
   return (
     <Box  as="form">
       <Box sx={{marginBottom: '24px'}} as="table">
+        <caption className={`visually-hidden`}>
+          Shopping Cart
+        </caption>
         <Box as="tr">
           <Box as="th" scope="col">
             Name
@@ -52,30 +55,29 @@ function CheckoutDetails() {
           const item = cartDetails[cartItem]
           return (
             <Box as="tr" key={item.sku}>
-              <Box tabIndex="0" as="td" scope="row">
+              <Box as="td" scope="row">
                 {item.name}
               </Box>
-              <Box tabIndex="0" as="td">
+              <Box as="td">
                 {item.description}
               </Box>
-              <Box tabIndex="0" as="td">
+              <Box as="td">
                 {item.formattedValue}
               </Box>
               <Box as="td">
-                <span
-                  id={'select-description'}
-                  className={'visually-hidden'}
-                >{`Change quantity of ${item.name}`}</span>
-                <Select
-                  aria-describedby={'select-description'}
-                  cartItem={item}
-                  max="50"
-                />
+                <label>
+                  <span className={`visually-hidden`}>
+                    Quantity of {item.name}
+                  </span>
+                  <Select
+                    cartItem={item}
+                    max="50"
+                  />
+                </label>
               </Box>
               <Box as="td">
                 <Close
-                  tabIndex="0"
-                  aria-roledescription={`Remove ${item.name} from cart`}
+                  aria-label={`Remove ${item.name} from cart`}
                   title={'Remove'}
                   onClick={() => removeItem(item.sku)}
                 />

--- a/src/components/select.js
+++ b/src/components/select.js
@@ -14,7 +14,6 @@ function Select({ max = 10, cartItem }) {
 
   return (
     <select
-      tabIndex="0"
       value={cartItem.quantity}
       fontSize={"20px"}
       onChange={event => {


### PR DESCRIPTION
Howdy! I adjusted the table markup a bit to make it a little more accessible. Here's what I did, and what my thought process was:

1. **I added a hidden `<caption>` element to the start of the table.** For screenreaders in particular, knowing [what an element is named](https://sarahmhigley.com/writing/whats-in-a-name/) is, well, the name of the game. That's the reason we'll use `aria-label` and `aria-labelledby`, for instance. Tables have a more semantic way to do that: [the `<caption>` element](https://www.w3.org/WAI/tutorials/tables/caption-summary/). Now when screenreader users navigate into the table, they'll be told that this is the "Shopping Cart" table. This is also important because screenreader users can use keyboard shortcuts or VoiceOver's "Rotor" to hop around on the page, and naming the table they might encounter gives them more context.

2. **I removed the `tabindex="0"` from the `<td>` cells.** In most cases, focusability implies interactivity. The rare exceptions are when we, for instance, add `tabindex="-1"` on a modal or other container because we know we'll need to programmatically focus the user on that container. I also removed `tabindex`es from the selects and buttons which were already focusable by default.

3. **I changed your "Remove" button's `aria-roledescription` into an `aria-label`.** Roles are for describing what kind of UI element this thing is—is it text, a checkbox, a dropdown, a button, etc. Semantic elements already implicitly have roles—the `<button>` element implicitly has the `button` role. `aria-roledescription` is for when you really need to introduce some new kind of UI control, and should be used with caution. [Léonie Watson has a great article about it.](https://tink.uk/using-the-aria-roledescription-attribute/) But here, I think it's totally fine for this button to stay a button. That "Remove $name from cart" text is a _great_ name for the button, though, which is why I set it as the button's `aria-label`.

4. **I replaced the `<select>`'s description span with a `<label>`.** Just as tables have the `<caption>` element to provide an accessible name, form elements have the `<label>`. There are two ways to use the `<label>` element. You could use it with the `for` attribute, setting that `for` to the `id` of the associated form element. This would require each of your items' `<select>`s to have a programmatically generated unique `id`. That's perfectly feasible (see comment below with an implementation), but I elected for the other approach. If you stick the form element _inside_ the `<label>`, automatically associate the form element with any text contents that are inside the same `<label>`—no `id`s required!